### PR TITLE
Metadata: add a function to access the stream map

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -145,6 +145,11 @@ func (m *Metadata) GetStream(name string) *StreamInfo {
 	return m.streams[name]
 }
 
+// Streams returns a map containing stream names and streams.
+func (m *Metadata) Streams() map[string]*StreamInfo {
+	return m.streams
+}
+
 // PartitionCountForStream returns the number of partitions for the given
 // stream.
 func (m *Metadata) PartitionCountForStream(stream string) int32 {

--- a/metadata.go
+++ b/metadata.go
@@ -137,15 +137,6 @@ func (m *Metadata) GetStream(name string) *StreamInfo {
 	return m.streams[name]
 }
 
-// Streams returns the list of known streams.
-func (m *Metadata) Streams() []*StreamInfo {
-	streams := make([]*StreamInfo, 0, len(m.streams))
-	for _, stream := range m.streams {
-		streams = append(streams, stream)
-	}
-	return streams
-}
-
 // PartitionCountForStream returns the number of partitions for the given
 // stream.
 func (m *Metadata) PartitionCountForStream(stream string) int32 {

--- a/metadata.go
+++ b/metadata.go
@@ -116,26 +116,18 @@ func (m *Metadata) LastUpdated() time.Time {
 
 // Brokers returns a list of the cluster nodes.
 func (m *Metadata) Brokers() []*BrokerInfo {
-	var (
-		brokers = make([]*BrokerInfo, len(m.brokers))
-		i       = 0
-	)
+	brokers := make([]*BrokerInfo, 0, len(m.brokers))
 	for _, broker := range m.brokers {
-		brokers[i] = broker
-		i++
+		brokers = append(brokers, broker)
 	}
 	return brokers
 }
 
 // Addrs returns the list of known broker addresses.
 func (m *Metadata) Addrs() []string {
-	var (
-		addrs = make([]string, len(m.addrs))
-		i     = 0
-	)
+	addrs := make([]string, 0, len(m.addrs))
 	for addr := range m.addrs {
-		addrs[i] = addr
-		i++
+		addrs = append(addrs, addr)
 	}
 	return addrs
 }
@@ -147,13 +139,9 @@ func (m *Metadata) GetStream(name string) *StreamInfo {
 
 // Streams returns the list of known streams.
 func (m *Metadata) Streams() []*StreamInfo {
-	var (
-		streams = make([]*StreamInfo, len(m.streams))
-		i       = 0
-	)
+	streams := make([]*StreamInfo, 0, len(m.streams))
 	for _, stream := range m.streams {
-		streams[i] = stream
-		i++
+		streams = append(streams, stream)
 	}
 	return streams
 }
@@ -216,13 +204,13 @@ func (m *metadataCache) update(ctx context.Context) (*Metadata, error) {
 			partitions: make(map[int32]*PartitionInfo, len(streamMetadata.Partitions)),
 		}
 		for _, partition := range streamMetadata.Partitions {
-			replicas := make([]*BrokerInfo, len(partition.Replicas))
-			for i, replica := range partition.Replicas {
-				replicas[i] = brokers[replica]
+			replicas := make([]*BrokerInfo, 0, len(partition.Replicas))
+			for _, replica := range partition.Replicas {
+				replicas = append(replicas, brokers[replica])
 			}
-			isr := make([]*BrokerInfo, len(partition.Isr))
-			for i, replica := range partition.Isr {
-				isr[i] = brokers[replica]
+			isr := make([]*BrokerInfo, 0, len(partition.Isr))
+			for _, replica := range partition.Isr {
+				isr = append(isr, brokers[replica])
 			}
 			stream.partitions[partition.Id] = &PartitionInfo{
 				id:       partition.Id,

--- a/metadata.go
+++ b/metadata.go
@@ -137,6 +137,15 @@ func (m *Metadata) GetStream(name string) *StreamInfo {
 	return m.streams[name]
 }
 
+// Streams returns the list of known streams.
+func (m *Metadata) Streams() []*StreamInfo {
+	streams := make([]*StreamInfo, 0, len(m.streams))
+	for _, stream := range m.streams {
+		streams = append(streams, stream)
+	}
+	return streams
+}
+
 // PartitionCountForStream returns the number of partitions for the given
 // stream.
 func (m *Metadata) PartitionCountForStream(stream string) int32 {

--- a/metadata.go
+++ b/metadata.go
@@ -145,9 +145,17 @@ func (m *Metadata) GetStream(name string) *StreamInfo {
 	return m.streams[name]
 }
 
-// Streams returns a map containing stream names and streams.
-func (m *Metadata) Streams() map[string]*StreamInfo {
-	return m.streams
+// Streams returns the list of known streams.
+func (m *Metadata) Streams() []*StreamInfo {
+	var (
+		streams = make([]*StreamInfo, len(m.streams))
+		i       = 0
+	)
+	for _, stream := range m.streams {
+		streams[i] = stream
+		i++
+	}
+	return streams
 }
 
 // PartitionCountForStream returns the number of partitions for the given

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -116,26 +116,18 @@ func (m *Metadata) LastUpdated() time.Time {
 
 // Brokers returns a list of the cluster nodes.
 func (m *Metadata) Brokers() []*BrokerInfo {
-	var (
-		brokers = make([]*BrokerInfo, len(m.brokers))
-		i       = 0
-	)
+	brokers := make([]*BrokerInfo, 0, len(m.brokers))
 	for _, broker := range m.brokers {
-		brokers[i] = broker
-		i++
+		brokers = append(brokers, broker)
 	}
 	return brokers
 }
 
 // Addrs returns the list of known broker addresses.
 func (m *Metadata) Addrs() []string {
-	var (
-		addrs = make([]string, len(m.addrs))
-		i     = 0
-	)
+	addrs := make([]string, 0, len(m.addrs))
 	for addr := range m.addrs {
-		addrs[i] = addr
-		i++
+		addrs = append(addrs, addr)
 	}
 	return addrs
 }
@@ -143,6 +135,15 @@ func (m *Metadata) Addrs() []string {
 // GetStream returns the given stream or nil if unknown.
 func (m *Metadata) GetStream(name string) *StreamInfo {
 	return m.streams[name]
+}
+
+// Streams returns the list of known streams.
+func (m *Metadata) Streams() []*StreamInfo {
+	streams := make([]*StreamInfo, 0, len(m.streams))
+	for _, stream := range m.streams {
+		streams = append(streams, stream)
+	}
+	return streams
 }
 
 // PartitionCountForStream returns the number of partitions for the given
@@ -203,13 +204,13 @@ func (m *metadataCache) update(ctx context.Context) (*Metadata, error) {
 			partitions: make(map[int32]*PartitionInfo, len(streamMetadata.Partitions)),
 		}
 		for _, partition := range streamMetadata.Partitions {
-			replicas := make([]*BrokerInfo, len(partition.Replicas))
-			for i, replica := range partition.Replicas {
-				replicas[i] = brokers[replica]
+			replicas := make([]*BrokerInfo, 0, len(partition.Replicas))
+			for _, replica := range partition.Replicas {
+				replicas = append(replicas, brokers[replica])
 			}
-			isr := make([]*BrokerInfo, len(partition.Isr))
-			for i, replica := range partition.Isr {
-				isr[i] = brokers[replica]
+			isr := make([]*BrokerInfo, 0, len(partition.Isr))
+			for _, replica := range partition.Isr {
+				isr = append(isr, brokers[replica])
 			}
 			stream.partitions[partition.Id] = &PartitionInfo{
 				id:       partition.Id,


### PR DESCRIPTION
This PR adds a function to access the stream map when fetching metadata. The current API only allows you to get a SteamInfo using a stream name.