### PR TITLE
Add an option to allow resuming a paused partition when subscribing

### DIFF
--- a/client.go
+++ b/client.go
@@ -526,8 +526,12 @@ type SubscriptionOptions struct {
 	// Partition sets the stream partition to consume.
 	Partition int32
 
-	// ReadISRReplica sets client's ability to subscribe from a random ISR
+	// ReadISRReplica sets client's ability to subscribe from a random ISR.
 	ReadISRReplica bool
+
+	// Resume controls if a paused partition can be resumed before
+	// subscription.
+	Resume bool
 }
 
 // SubscriptionOption is a function on the SubscriptionOptions for a
@@ -589,6 +593,16 @@ func StartAtEarliestReceived() SubscriptionOption {
 func ReadISRReplica() SubscriptionOption {
 	return func(o *SubscriptionOptions) error {
 		o.ReadISRReplica = true
+		return nil
+	}
+}
+
+// Resume controls if a paused partition can be resumed before subscription. If
+// true, subscribing to a paused partition will resume it before subscribing to
+// it instead of failing.
+func Resume() SubscriptionOption {
+	return func(o *SubscriptionOptions) error {
+		o.Resume = true
 		return nil
 	}
 }
@@ -787,6 +801,7 @@ func (c *client) subscribe(ctx context.Context, stream string,
 				StartTimestamp: opts.StartTimestamp.UnixNano(),
 				Partition:      opts.Partition,
 				ReadISRReplica: opts.ReadISRReplica,
+				Resume:         opts.Resume,
 			}
 		)
 		st, err = client.Subscribe(ctx, req)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.4.1
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/liftbridge-io/liftbridge-api v1.0.0
+	github.com/liftbridge-io/liftbridge-api v1.1.1-0.20200828094752-af34f7c64cb7
 	github.com/nats-io/nats-server/v2 v2.1.4 // indirect
 	github.com/nats-io/nats.go v1.9.2
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/liftbridge-io/liftbridge-api v1.0.0 h1:rtbdxtPq/ebPK7Og9mSbziDsQ2WZpPE7ZVL/BKc3CPU=
-github.com/liftbridge-io/liftbridge-api v1.0.0/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=


### PR DESCRIPTION
Liftbridge offers the option of pausing a stream (with some or all of its partitions) to reduce the amount of CPU and memory usage on idle streams. When that happens, every subscriber to a partition receives an error. Publishing to a paused partition will resume it, allowing it to function as before.

Our use-case includes a situation where we would like to read from a partition even if it is paused. It has to be resumed to do so, but we do not want to publish to it. This PR adds an option to the subscription request to allow it to resume a partition instead of returning an error.