### PR TITLE
Use map to store mock responses in tests

### DIFF
--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -103,7 +103,7 @@ func TestCreateStream(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -120,7 +120,8 @@ func TestCreateStream(t *testing.T) {
 	require.Equal(t, int32(2), req.ReplicationFactor)
 	require.Equal(t, int32(0), req.Partitions)
 
-	server.SetupMockResponse(new(proto.CreateStreamResponse))
+	server.SetupMockCreateStreamError(nil)
+	server.SetupMockCreateStreamResponse(new(proto.CreateStreamResponse))
 
 	require.NoError(t, client.CreateStream(context.Background(), "foo", "bar",
 		Group("group"), MaxReplication(), Partitions(3)))
@@ -140,7 +141,7 @@ func TestDeleteStream(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -152,7 +153,8 @@ func TestDeleteStream(t *testing.T) {
 	require.Equal(t, ErrNoSuchStream, err)
 	require.Equal(t, "foo", server.GetDeleteStreamRequests()[0].Name)
 
-	server.SetupMockResponse(new(proto.DeleteStreamResponse))
+	server.SetupMockDeleteStreamError(nil)
+	server.SetupMockDeleteStreamResponse(new(proto.DeleteStreamResponse))
 
 	require.NoError(t, client.DeleteStream(context.Background(), "foo"))
 	require.Equal(t, "foo", server.GetDeleteStreamRequests()[1].Name)
@@ -163,7 +165,7 @@ func TestPauseStream(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -178,7 +180,8 @@ func TestPauseStream(t *testing.T) {
 	require.Equal(t, []int32(nil), req.Partitions)
 	require.False(t, req.ResumeAll)
 
-	server.SetupMockResponse(new(proto.PauseStreamResponse))
+	server.SetupMockPauseStreamError(nil)
+	server.SetupMockPausetreamResponse(new(proto.PauseStreamResponse))
 
 	require.NoError(t, client.PauseStream(context.Background(), "foo",
 		PausePartitions(0, 1), ResumeAll()))
@@ -193,7 +196,7 @@ func TestSetStreamReadonly(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -208,7 +211,8 @@ func TestSetStreamReadonly(t *testing.T) {
 	require.Equal(t, []int32(nil), req.Partitions)
 	require.True(t, req.Readonly)
 
-	server.SetupMockResponse(new(proto.SetStreamReadonlyResponse))
+	server.SetupMockSetStreamReadonlyError(nil)
+	server.SetupMockSetStreamReadonlyResponse(new(proto.SetStreamReadonlyResponse))
 
 	require.NoError(t, client.SetStreamReadonly(context.Background(), "foo",
 		ReadonlyPartitions(0, 1), Readonly(false)))
@@ -223,7 +227,7 @@ func TestSubscribe(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -248,7 +252,7 @@ func TestSubscribe(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	timestamp := time.Now().UnixNano()
 	messages := []*proto.Message{
 		{
@@ -298,7 +302,7 @@ func TestSubscribeNoKnownPartition(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -323,7 +327,7 @@ func TestSubscribeNoKnownPartition(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp, metadataResp, metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	err = client.Subscribe(context.Background(), "foo", func(msg *Message, err error) {}, Partition(1))
 	require.Error(t, err)
@@ -337,7 +341,7 @@ func TestSubscribeNoPartition(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -362,7 +366,7 @@ func TestSubscribeNoPartition(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp, metadataResp, metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	server.SetupMockSubscribeError(status.Error(codes.NotFound, "No such partition"))
 
 	err = client.Subscribe(context.Background(), "foo", func(msg *Message, err error) {},
@@ -382,7 +386,7 @@ func TestSubscribeNoKnownStream(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -396,7 +400,7 @@ func TestSubscribeNoKnownStream(t *testing.T) {
 		}},
 		Metadata: []*proto.StreamMetadata{},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp, metadataResp, metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	err = client.Subscribe(context.Background(), "foo", func(msg *Message, err error) {})
 	require.Error(t, err)
@@ -410,7 +414,7 @@ func TestSubscribeNoLeader(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -433,7 +437,7 @@ func TestSubscribeNoLeader(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp, metadataResp, metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	err = client.Subscribe(context.Background(), "foo", func(msg *Message, err error) {})
 	require.Error(t, err)
@@ -444,10 +448,15 @@ func TestSubscribeNoLeader(t *testing.T) {
 
 func TestSubscribeNotLeaderRetry(t *testing.T) {
 	server := newMockServer()
+	// Set autoClearError for testing retry requests
+	server.mu.Lock()
+	server.autoClearError = true
+	server.mu.Unlock()
+
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -472,7 +481,7 @@ func TestSubscribeNotLeaderRetry(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	timestamp := time.Now().UnixNano()
 	messages := []*proto.Message{
 		{
@@ -521,10 +530,16 @@ func TestSubscribeNotLeaderRetry(t *testing.T) {
 
 func TestSubscribeResubscribe(t *testing.T) {
 	server := newMockServer()
+
+	// Set autoClearError for testing retry requests
+	server.mu.Lock()
+	server.autoClearError = true
+	server.mu.Unlock()
+
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -549,7 +564,7 @@ func TestSubscribeResubscribe(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	timestamp := time.Now().UnixNano()
 	messages := []*proto.Message{
 		{
@@ -620,7 +635,7 @@ func TestSubscribeStreamDeleted(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -674,7 +689,7 @@ func TestSubscribePartitionPaused(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -704,6 +719,12 @@ func TestSubscribePartitionPaused(t *testing.T) {
 
 func TestSubscribeServerUnavailableRetry(t *testing.T) {
 	server := newMockServer()
+	// Set autoClearError for testing retry requests
+
+	server.mu.Lock()
+	server.autoClearError = true
+	server.mu.Unlock()
+
 	defer server.Stop(t)
 	port := server.Start(t)
 
@@ -726,7 +747,7 @@ func TestSubscribeServerUnavailableRetry(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -734,8 +755,14 @@ func TestSubscribeServerUnavailableRetry(t *testing.T) {
 
 	server.Stop(t)
 	server = newMockServer()
+
+	// Set autoClearError for testing retry requests
+	server.mu.Lock()
+	server.autoClearError = true
+	server.mu.Unlock()
+
 	defer server.Stop(t)
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	timestamp := time.Now().UnixNano()
 	messages := []*proto.Message{
 		{
@@ -792,7 +819,7 @@ func TestSubscribeInvalidPartition(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -809,7 +836,7 @@ func TestPublish(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -824,7 +851,7 @@ func TestPublish(t *testing.T) {
 		AckPolicy:        proto.AckPolicy_LEADER,
 	}
 
-	server.SetupMockResponse(&proto.PublishResponse{Ack: expectedAck})
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{Ack: expectedAck})
 
 	ack, err := client.Publish(context.Background(), "foo", []byte("hello"))
 	require.NoError(t, err)
@@ -852,7 +879,7 @@ func TestPublishAckPolicyNone(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -885,7 +912,7 @@ func TestPublishAckTimeout(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)},
 		AckWaitTime(time.Nanosecond))
@@ -901,7 +928,7 @@ func TestPublishAsync(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -916,7 +943,7 @@ func TestPublishAsync(t *testing.T) {
 		AckPolicy:        proto.AckPolicy_LEADER,
 	}
 
-	server.SetupMockResponse(&proto.PublishResponse{Ack: expectedAck})
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{Ack: expectedAck})
 
 	ackC := make(chan *Ack)
 	err = client.PublishAsync(context.Background(), "foo", []byte("hello"),
@@ -956,7 +983,7 @@ func TestPublishAsyncAckTimeout(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -985,13 +1012,13 @@ func TestPublishAsyncPartitionNotFound(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
 	defer client.Close()
 
-	server.SetupMockResponse(&proto.PublishResponse{
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{
 		AsyncError: &proto.PublishAsyncError{
 			Code:    proto.PublishAsyncError_NOT_FOUND,
 			Message: "partition not found",
@@ -1018,13 +1045,13 @@ func TestPublishAsyncReadonlyPartition(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
 	defer client.Close()
 
-	server.SetupMockResponse(&proto.PublishResponse{
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{
 		AsyncError: &proto.PublishAsyncError{
 			Code:    proto.PublishAsyncError_READONLY,
 			Message: "partition is readonly",
@@ -1051,13 +1078,13 @@ func TestPublishAsyncInternalError(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
 	defer client.Close()
 
-	server.SetupMockResponse(&proto.PublishResponse{
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{
 		AsyncError: &proto.PublishAsyncError{
 			Code:    proto.PublishAsyncError_UNKNOWN,
 			Message: "internal error",
@@ -1085,7 +1112,7 @@ func TestPublishToPartition(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1101,7 +1128,7 @@ func TestPublishToPartition(t *testing.T) {
 		AckPolicy:        proto.AckPolicy_ALL,
 	}
 
-	server.SetupMockResponse(&proto.PublishResponse{Ack: expectedAck})
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{Ack: expectedAck})
 
 	ack, err := client.Publish(context.Background(), "foo", []byte("hello"),
 		ToPartition(1), Key([]byte("key")), AckPolicyAll(), Header("foo", []byte("bar")))
@@ -1156,20 +1183,20 @@ func TestPublishRoundRobin(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
 	defer client.Close()
 
-	server.SetupMockResponse(&proto.PublishResponse{
+	server.SetupMockPublishAsyncResponse(&proto.PublishResponse{
 		Ack: &proto.Ack{},
 	})
 	_, err = client.Publish(context.Background(), "foo", []byte("hello"),
 		PartitionByRoundRobin())
 	require.NoError(t, err)
 
-	server.SetupMockResponse(&proto.PublishResponse{
+	server.SetupMockPublishToSubjectResponse(&proto.PublishResponse{
 		Ack: &proto.Ack{},
 	})
 	_, err = client.Publish(context.Background(), "foo", []byte("hello"),
@@ -1194,7 +1221,7 @@ func TestPublishToSubject(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1210,7 +1237,7 @@ func TestPublishToSubject(t *testing.T) {
 		AckPolicy:        proto.AckPolicy_LEADER,
 	}
 
-	server.SetupMockResponse(&proto.PublishToSubjectResponse{Ack: expectedAck})
+	server.SetupMockPublishToSubjectResponse(&proto.PublishToSubjectResponse{Ack: expectedAck})
 
 	ack, err := client.PublishToSubject(context.Background(), "foo", []byte("hello"), Key([]byte("key")))
 	require.NoError(t, err)
@@ -1237,7 +1264,7 @@ func TestPublishToSubjectAckTimeout(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1273,7 +1300,7 @@ func TestFetchMetadata(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1327,7 +1354,7 @@ func TestSubscribeDisconnectError(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)}, ResubscribeWaitTime(0))
 	require.NoError(t, err)
@@ -1371,7 +1398,7 @@ func TestResubscribeFail(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockResponse(metadataResp, metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)},
 		ResubscribeWaitTime(time.Millisecond))
@@ -1451,7 +1478,7 @@ func TestSetCursor(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1476,8 +1503,8 @@ func TestSetCursor(t *testing.T) {
 			},
 		}},
 	}
-
-	server.SetupMockResponse(metadataResp, new(proto.SetCursorResponse))
+	server.SetupMockFetchMetadataResponse(metadataResp)
+	server.SetupMockSetCursorResponse(new(proto.SetCursorResponse))
 
 	err = client.SetCursor(context.Background(), "foo", "bar", 1, 5)
 	require.NoError(t, err)
@@ -1496,7 +1523,7 @@ func TestSetCursorNotLeader(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1522,7 +1549,7 @@ func TestSetCursorNotLeader(t *testing.T) {
 		}},
 	}
 
-	server.SetupMockResponse(metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	server.SetupMockSetCursorError(status.Error(codes.FailedPrecondition, "server is not partition leader"))
 
 	err = client.SetCursor(context.Background(), "foo", "bar", 2, 5)
@@ -1534,7 +1561,7 @@ func TestFetchCursor(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1561,7 +1588,8 @@ func TestFetchCursor(t *testing.T) {
 	}
 
 	resp := &proto.FetchCursorResponse{Offset: 11}
-	server.SetupMockResponse(metadataResp, resp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
+	server.SetupMockFetchCursorRequestsResponse(resp)
 
 	offset, err := client.FetchCursor(context.Background(), "foo", "bar", 1)
 	require.NoError(t, err)
@@ -1580,7 +1608,7 @@ func TestFetchCursorNotLeader(t *testing.T) {
 	defer server.Stop(t)
 	port := server.Start(t)
 
-	server.SetupMockResponse(new(proto.FetchMetadataResponse))
+	server.SetupMockFetchMetadataResponse(new(proto.FetchMetadataResponse))
 
 	client, err := Connect([]string{fmt.Sprintf("localhost:%d", port)})
 	require.NoError(t, err)
@@ -1606,7 +1634,7 @@ func TestFetchCursorNotLeader(t *testing.T) {
 		}},
 	}
 
-	server.SetupMockResponse(metadataResp)
+	server.SetupMockFetchMetadataResponse(metadataResp)
 	server.SetupMockFetchCursorError(status.Error(codes.FailedPrecondition, "server is not partition leader"))
 
 	_, err = client.FetchCursor(context.Background(), "foo", "bar", 2)

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -448,10 +448,7 @@ func TestSubscribeNoLeader(t *testing.T) {
 
 func TestSubscribeNotLeaderRetry(t *testing.T) {
 	server := newMockServer()
-	// Set autoClearError for testing retry requests
-	server.mu.Lock()
-	server.autoClearError = true
-	server.mu.Unlock()
+	server.SetAutoClearError()
 
 	defer server.Stop(t)
 	port := server.Start(t)
@@ -531,10 +528,7 @@ func TestSubscribeNotLeaderRetry(t *testing.T) {
 func TestSubscribeResubscribe(t *testing.T) {
 	server := newMockServer()
 
-	// Set autoClearError for testing retry requests
-	server.mu.Lock()
-	server.autoClearError = true
-	server.mu.Unlock()
+	server.SetAutoClearError()
 
 	defer server.Stop(t)
 	port := server.Start(t)
@@ -719,11 +713,7 @@ func TestSubscribePartitionPaused(t *testing.T) {
 
 func TestSubscribeServerUnavailableRetry(t *testing.T) {
 	server := newMockServer()
-	// Set autoClearError for testing retry requests
-
-	server.mu.Lock()
-	server.autoClearError = true
-	server.mu.Unlock()
+	server.SetAutoClearError()
 
 	defer server.Stop(t)
 	port := server.Start(t)
@@ -756,10 +746,7 @@ func TestSubscribeServerUnavailableRetry(t *testing.T) {
 	server.Stop(t)
 	server = newMockServer()
 
-	// Set autoClearError for testing retry requests
-	server.mu.Lock()
-	server.autoClearError = true
-	server.mu.Unlock()
+	server.SetAutoClearError()
 
 	defer server.Stop(t)
 	server.SetupMockFetchMetadataResponse(metadataResp)

--- a/v2/common_test.go
+++ b/v2/common_test.go
@@ -119,7 +119,7 @@ type mockAPI struct {
 	publishToSubjectRequests  []*proto.PublishToSubjectRequest
 	setCursorRequests         []*proto.SetCursorRequest
 	fetchCursorRequests       []*proto.FetchCursorRequest
-	responses                 []interface{}
+	responses                 map[string]interface{}
 	messages                  []*proto.Message
 	createStreamErr           error
 	deleteStreamErr           error
@@ -133,6 +133,8 @@ type mockAPI struct {
 	publishToSubjectErr       error
 	setCursorErr              error
 	fetchCursorErr            error
+	// autclearError indicates where the mock API shall clear mock error automatically
+	autoClearError bool
 }
 
 func newMockAPI() *mockAPI {
@@ -147,13 +149,49 @@ func newMockAPI() *mockAPI {
 		publishToSubjectRequests:  []*proto.PublishToSubjectRequest{},
 		setCursorRequests:         []*proto.SetCursorRequest{},
 		fetchCursorRequests:       []*proto.FetchCursorRequest{},
+		responses:                 make(map[string]interface{}),
+		autoClearError:            false,
 	}
 }
 
-func (m *mockAPI) SetupMockResponse(responses ...interface{}) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.responses = responses
+func (m *mockAPI) SetupMockCreateStreamResponse(response interface{}) {
+	m.responses["CreateStream"] = response
+}
+
+func (m *mockAPI) SetupMockDeleteStreamResponse(responses interface{}) {
+	m.responses["DeleteStream"] = responses
+}
+
+func (m *mockAPI) SetupMockPausetreamResponse(responses interface{}) {
+	m.responses["PauseStream"] = responses
+}
+
+func (m *mockAPI) SetupMockSetStreamReadonlyResponse(response interface{}) {
+	m.responses["SetStreamReadonly"] = response
+}
+
+func (m *mockAPI) SetupMockSubscribeResponse(responses interface{}) {
+	m.responses["SetSubscribe"] = responses
+}
+
+func (m *mockAPI) SetupMockFetchMetadataResponse(response interface{}) {
+	m.responses["FetchMetadata"] = response
+}
+
+func (m *mockAPI) SetupMockPublishAsyncResponse(responses interface{}) {
+	m.responses["PublishAsync"] = responses
+}
+
+func (m *mockAPI) SetupMockPublishToSubjectResponse(responses interface{}) {
+	m.responses["PublishToSubject"] = responses
+}
+
+func (m *mockAPI) SetupMockSetCursorResponse(responses interface{}) {
+	m.responses["SetCursor"] = responses
+}
+
+func (m *mockAPI) SetupMockFetchCursorRequestsResponse(responses interface{}) {
+	m.responses["FetchCursor"] = responses
 }
 
 func (m *mockAPI) SetupMockCreateStreamError(err error) {
@@ -294,25 +332,18 @@ func (m *mockAPI) GetFetchMetadataRequests() []*proto.FetchMetadataRequest {
 	return m.fetchMetadataRequests
 }
 
-func (m *mockAPI) getResponse() interface{} {
-	if len(m.responses) == 0 {
-		return nil
-	}
-	resp := m.responses[0]
-	m.responses = m.responses[1:]
-	return resp
-}
-
 func (m *mockAPI) CreateStream(ctx context.Context, in *proto.CreateStreamRequest) (*proto.CreateStreamResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.createStreamRequests = append(m.createStreamRequests, in)
 	if m.createStreamErr != nil {
 		err := m.createStreamErr
-		m.createStreamErr = nil
+		if m.autoClearError {
+			m.createStreamErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["CreateStream"]
 	return resp.(*proto.CreateStreamResponse), nil
 }
 
@@ -322,10 +353,12 @@ func (m *mockAPI) DeleteStream(ctx context.Context, in *proto.DeleteStreamReques
 	m.deleteStreamRequests = append(m.deleteStreamRequests, in)
 	if m.deleteStreamErr != nil {
 		err := m.deleteStreamErr
-		m.deleteStreamErr = nil
+		if m.autoClearError {
+			m.deleteStreamErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["DeleteStream"]
 	return resp.(*proto.DeleteStreamResponse), nil
 }
 
@@ -335,10 +368,12 @@ func (m *mockAPI) PauseStream(ctx context.Context, in *proto.PauseStreamRequest)
 	m.pauseStreamRequests = append(m.pauseStreamRequests, in)
 	if m.pauseStreamErr != nil {
 		err := m.pauseStreamErr
-		m.pauseStreamErr = nil
+		if m.autoClearError {
+			m.pauseStreamErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["PauseStream"]
 	return resp.(*proto.PauseStreamResponse), nil
 }
 
@@ -348,10 +383,12 @@ func (m *mockAPI) SetStreamReadonly(ctx context.Context, in *proto.SetStreamRead
 	m.setStreamReadonlyRequests = append(m.setStreamReadonlyRequests, in)
 	if m.setStreamReadonlyErr != nil {
 		err := m.setStreamReadonlyErr
-		m.setStreamReadonlyErr = nil
+		if m.autoClearError {
+			m.setCursorErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["SetStreamReadonly"]
 	return resp.(*proto.SetStreamReadonlyResponse), nil
 }
 
@@ -360,14 +397,18 @@ func (m *mockAPI) Subscribe(in *proto.SubscribeRequest, server proto.API_Subscri
 	m.subscribeRequests = append(m.subscribeRequests, in)
 	if m.subscribeErr != nil {
 		err := m.subscribeErr
-		m.subscribeErr = nil
+		if m.autoClearError {
+			m.subscribeErr = nil
+		}
 		m.mu.Unlock()
 		return err
 	}
 	server.Send(new(proto.Message))
 	if m.subscribeAsyncErr != nil {
 		err := m.subscribeAsyncErr
-		m.subscribeAsyncErr = nil
+		if m.autoClearError {
+			m.subscribeAsyncErr = nil
+		}
 		m.mu.Unlock()
 		return err
 	}
@@ -385,10 +426,12 @@ func (m *mockAPI) FetchMetadata(ctx context.Context, in *proto.FetchMetadataRequ
 	m.fetchMetadataRequests = append(m.fetchMetadataRequests, in)
 	if m.fetchMetadataErr != nil {
 		err := m.fetchMetadataErr
-		m.fetchMetadataErr = nil
+		if m.autoClearError {
+			m.fetchMetadataErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["FetchMetadata"]
 	return resp.(*proto.FetchMetadataResponse), nil
 }
 
@@ -405,6 +448,9 @@ func (m *mockAPI) PublishAsync(stream proto.API_PublishAsyncServer) error {
 	if m.publishAsyncErr != nil {
 		err := m.publishAsyncErr
 		m.publishAsyncErr = nil
+		if m.autoClearError {
+			m.publishAsyncErr = nil
+		}
 		m.mu.Unlock()
 		return err
 	}
@@ -422,7 +468,7 @@ func (m *mockAPI) PublishAsync(stream proto.API_PublishAsyncServer) error {
 		m.mu.Unlock()
 
 		if req.AckPolicy != proto.AckPolicy_NONE {
-			respIface := m.getResponse()
+			respIface := m.responses["PublishAsync"]
 			if respIface == nil {
 				continue
 			}
@@ -442,10 +488,12 @@ func (m *mockAPI) PublishToSubject(ctx context.Context, in *proto.PublishToSubje
 	m.publishToSubjectRequests = append(m.publishToSubjectRequests, in)
 	if m.publishToSubjectErr != nil {
 		err := m.publishToSubjectErr
-		m.publishToSubjectErr = nil
+		if m.autoClearError {
+			m.publishToSubjectErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["PublishToSubject"]
 	return resp.(*proto.PublishToSubjectResponse), nil
 }
 
@@ -455,10 +503,12 @@ func (m *mockAPI) SetCursor(ctx context.Context, in *proto.SetCursorRequest) (*p
 	m.setCursorRequests = append(m.setCursorRequests, in)
 	if m.setCursorErr != nil {
 		err := m.setCursorErr
-		m.setCursorErr = nil
+		if m.autoClearError {
+			m.setCursorErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["SetCursor"]
 	return resp.(*proto.SetCursorResponse), nil
 }
 
@@ -468,9 +518,11 @@ func (m *mockAPI) FetchCursor(ctx context.Context, in *proto.FetchCursorRequest)
 	m.fetchCursorRequests = append(m.fetchCursorRequests, in)
 	if m.fetchCursorErr != nil {
 		err := m.fetchCursorErr
-		m.fetchCursorErr = nil
+		if m.autoClearError {
+			m.fetchCursorErr = nil
+		}
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responses["FetchCursor"]
 	return resp.(*proto.FetchCursorResponse), nil
 }

--- a/v2/common_test.go
+++ b/v2/common_test.go
@@ -154,6 +154,13 @@ func newMockAPI() *mockAPI {
 	}
 }
 
+// SetAutoClearError activate auto clearing mock error
+func (m *mockAPI) SetAutoClearError() {
+	m.mu.Lock()
+	m.autoClearError = true
+	m.mu.Unlock()
+}
+
 func (m *mockAPI) SetupMockCreateStreamResponse(response interface{}) {
 	m.responses["CreateStream"] = response
 }


### PR DESCRIPTION
### Context

The current test behavior stores mock responses as an array in the mock API struct

```golang

type mockAPI struct {
	mu                        sync.Mutex
	responses                 []interface{}
....
}
```

This does not differentiate the responses of different rpc endpoints. Thus, in order to simulate different scenarios, the order in which the mock responses are stored is important.

In my opinion, the mock API should be:

1. Deterministic : The rpc should returns mocked result consistently, regardless of how we store the mock responses' order

2. Idempotent: The mock endpoint can be hit multiple times and still expect to return same results. It would be a bit easier to debug tests

3. Isolate: responses of one mock rpc endpoint should not affect the mock response of other endpoint.

### Changes proposed in the PR

1. `responses` should be a map, with key of the map is the name of the rpc endpoint.

2. Each endpoint should have its own method to set up its mock response, just like what is happening now with error mocking:

```golang
func (m *mockAPI) SetupMockSetStreamReadonlyError(err error) {
	m.mu.Lock()
	defer m.mu.Unlock()
	m.setStreamReadonlyErr = err
}
```

3. Add a flag called `autoClearError` to indicate whether the mock API should clear mock error automatically or not . This behavior is practical for scenarios where retry is used. By default , it is deactivated.

Please let me know what do you think about this.