### PR TITLE
Implement FetchPartitionMetadata 

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -481,6 +481,9 @@ type Client interface {
 	// FetchCursor retrieves a cursor position for a particular stream
 	// partition. It returns -1 if the cursor does not exist.
 	FetchCursor(ctx context.Context, id, stream string, partition int32) (int64, error)
+
+	// FetchPartitionMetadata retrieves the metadata of a particular partition
+	FetchPartitionMetadata(ctx context.Context, stream string, partition int32) (*PartitionMetadata, error)
 }
 
 // client implements the Client interface. It maintains a pool of connections
@@ -1183,6 +1186,36 @@ func (c *client) FetchMetadata(ctx context.Context) (*Metadata, error) {
 	return c.metadata.update(ctx)
 }
 
+// FetchPartitionMetadata returns the metadata of the partition. This is sent to
+// the partition's leader
+func (c *client) FetchPartitionMetadata(ctx context.Context, stream string, partition int32) (*PartitionMetadata, error) {
+	var (
+		req               = &proto.FetchPartitionMetadataRequest{Stream: stream, Partition: partition}
+		partitionMetadata = &PartitionMetadata{}
+	)
+	err := c.doResilientLeaderRPC(ctx, func(client proto.APIClient) error {
+		resp, err := client.FetchPartitionMetadata(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		partitionMetadata.id = resp.GetMetadata().GetId()
+		partitionMetadata.leader = resp.GetMetadata().GetLeader()
+		partitionMetadata.replicas = resp.GetMetadata().GetIsr()
+		partitionMetadata.isr = resp.GetMetadata().GetIsr()
+		partitionMetadata.highWatermark = resp.GetMetadata().GetHighWatermark()
+		partitionMetadata.newestOffset = resp.GetMetadata().GetNewestOffset()
+		partitionMetadata.paused = resp.GetMetadata().GetPaused()
+
+		return nil
+	}, stream, partition)
+
+	if err != nil {
+		return nil, err
+	}
+	return partitionMetadata, nil
+}
+
 // SetCursor persists a cursor position for a particular stream partition.
 // This can be used to checkpoint a consumer's position in a stream to resume
 // processing later.
@@ -1586,7 +1619,7 @@ func (c *client) doResilientLeaderRPC(ctx context.Context, rpc func(client proto
 		err = rpc(conn)
 		pool.put(conn)
 		if err != nil {
-			if status.Code(err) == codes.Unavailable {
+			if status.Code(err) == codes.Unavailable || status.Code(err) == codes.FailedPrecondition {
 				time.Sleep(50 * time.Millisecond)
 				c.metadata.update(ctx)
 				continue

--- a/v2/client.go
+++ b/v2/client.go
@@ -1199,13 +1199,13 @@ func (c *client) FetchPartitionMetadata(ctx context.Context, stream string, part
 			return err
 		}
 
-		partitionMetadata.id = resp.GetMetadata().GetId()
-		partitionMetadata.leader = resp.GetMetadata().GetLeader()
-		partitionMetadata.replicas = resp.GetMetadata().GetIsr()
-		partitionMetadata.isr = resp.GetMetadata().GetIsr()
-		partitionMetadata.highWatermark = resp.GetMetadata().GetHighWatermark()
-		partitionMetadata.newestOffset = resp.GetMetadata().GetNewestOffset()
-		partitionMetadata.paused = resp.GetMetadata().GetPaused()
+		partitionMetadata.ID = resp.GetMetadata().GetId()
+		partitionMetadata.Leader = resp.GetMetadata().GetLeader()
+		partitionMetadata.Replicas = resp.GetMetadata().GetIsr()
+		partitionMetadata.Isr = resp.GetMetadata().GetIsr()
+		partitionMetadata.HighWatermark = resp.GetMetadata().GetHighWatermark()
+		partitionMetadata.NewestOffset = resp.GetMetadata().GetNewestOffset()
+		partitionMetadata.Paused = resp.GetMetadata().GetPaused()
 
 		return nil
 	}, stream, partition)

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1671,8 +1671,8 @@ func TestFetchPartitionMetadata(t *testing.T) {
 
 	resp, err := client.FetchPartitionMetadata(context.Background(), "foo", 0)
 	require.NoError(t, err)
-	require.Equal(t, int64(100), resp.HighWatermark)
-	require.Equal(t, int64(105), resp.NewestOffset)
+	require.Equal(t, int64(100), resp.HighWatermark())
+	require.Equal(t, int64(105), resp.NewestOffset())
 
 }
 

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1539,7 +1539,6 @@ func TestSetCursorNotLeader(t *testing.T) {
 	server.SetupMockFetchMetadataResponse(metadataResp)
 	server.SetupMockSetCursorError(status.Error(codes.FailedPrecondition, "server is not partition leader"))
 
-	server.SetupMockSetCursorError(status.Error(codes.FailedPrecondition, "server is not partition leader"))
 	err = client.SetCursor(context.Background(), "foo", "bar", 2, 5)
 	require.Error(t, err)
 }
@@ -1574,7 +1573,6 @@ func TestFetchCursor(t *testing.T) {
 			},
 		}},
 	}
-	server.SetupMockFetchMetadataResponse(metadataResp)
 
 	resp := &proto.FetchCursorResponse{Offset: 11}
 	server.SetupMockFetchMetadataResponse(metadataResp)
@@ -1673,8 +1671,8 @@ func TestFetchPartitionMetadata(t *testing.T) {
 
 	resp, err := client.FetchPartitionMetadata(context.Background(), "foo", 0)
 	require.NoError(t, err)
-	require.Equal(t, int64(100), resp.highWatermark)
-	require.Equal(t, int64(105), resp.newestOffset)
+	require.Equal(t, int64(100), resp.HighWatermark)
+	require.Equal(t, int64(105), resp.NewestOffset)
 
 }
 

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1674,6 +1674,16 @@ func TestFetchPartitionMetadata(t *testing.T) {
 	require.Equal(t, int64(100), resp.HighWatermark())
 	require.Equal(t, int64(105), resp.NewestOffset())
 
+	// Expect broker info exists for leader, isr and replicas
+	broker := &BrokerInfo{id: "a",
+		host: "localhost",
+		port: int32(port)}
+
+	expectedISR := []*BrokerInfo{broker}
+	expectedReplicas := []*BrokerInfo{broker}
+	require.Equal(t, broker, resp.Leader())
+	require.Equal(t, expectedISR, resp.ISR())
+	require.Equal(t, expectedReplicas, resp.Replicas())
 }
 
 func TestFetchPartitionMetadataNotLeader(t *testing.T) {

--- a/v2/common_test.go
+++ b/v2/common_test.go
@@ -120,6 +120,7 @@ type mockAPI struct {
 	fetchCursorRequests            []*proto.FetchCursorRequest
 	fetchPartitionMetadataRequests []*proto.FetchPartitionMetadataRequest
 	responses                      []interface{}
+	responsesMap                   map[string]interface{}
 	messages                       []*proto.Message
 	createStreamErr                error
 	deleteStreamErr                error
@@ -149,6 +150,7 @@ func newMockAPI() *mockAPI {
 		setCursorRequests:              []*proto.SetCursorRequest{},
 		fetchCursorRequests:            []*proto.FetchCursorRequest{},
 		fetchPartitionMetadataRequests: []*proto.FetchPartitionMetadataRequest{},
+		responsesMap:                   make(map[string]interface{}),
 	}
 }
 
@@ -156,6 +158,28 @@ func (m *mockAPI) SetupMockResponse(responses ...interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.responses = responses
+}
+
+func (m *mockAPI) SetupMockCreateStreamResponse(responses interface{}) {
+	m.responsesMap["CreateStream"] = responses
+}
+
+func (m *mockAPI) SetupMockFetchMetadataResponse(responses interface{}) {
+	m.responsesMap["FetchMetadata"] = responses
+}
+
+func (m *mockAPI) SetupMockFetchCursorResponse(responses interface{}) {
+	m.responsesMap["FetchCursor"] = responses
+}
+
+func (m *mockAPI) SetupMockFetchPartitionMetadataResponse(responses interface{}) {
+	m.responsesMap["FetchPartitionMetadata"] = responses
+}
+
+func (m *mockAPI) AppendMockResponse(responses ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses = append(m.responses, responses...)
 }
 
 func (m *mockAPI) SetupMockCreateStreamError(err error) {
@@ -320,7 +344,7 @@ func (m *mockAPI) CreateStream(ctx context.Context, in *proto.CreateStreamReques
 		m.createStreamErr = nil
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responsesMap["CreateStream"]
 	return resp.(*proto.CreateStreamResponse), nil
 }
 
@@ -396,7 +420,7 @@ func (m *mockAPI) FetchMetadata(ctx context.Context, in *proto.FetchMetadataRequ
 		m.fetchMetadataErr = nil
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responsesMap["FetchMetadata"]
 	return resp.(*proto.FetchMetadataResponse), nil
 }
 
@@ -406,10 +430,9 @@ func (m *mockAPI) FetchPartitionMetadata(ctx context.Context, in *proto.FetchPar
 	m.fetchPartitionMetadataRequests = append(m.fetchPartitionMetadataRequests, in)
 	if m.fetchPartitionMetadataErr != nil {
 		err := m.fetchPartitionMetadataErr
-		m.fetchPartitionMetadataErr = nil
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responsesMap["FetchPartitionMetadata"]
 	return resp.(*proto.FetchPartitionMetadataResponse), nil
 }
 
@@ -485,9 +508,8 @@ func (m *mockAPI) FetchCursor(ctx context.Context, in *proto.FetchCursorRequest)
 	m.fetchCursorRequests = append(m.fetchCursorRequests, in)
 	if m.fetchCursorErr != nil {
 		err := m.fetchCursorErr
-		m.fetchCursorErr = nil
 		return nil, err
 	}
-	resp := m.getResponse()
+	resp := m.responsesMap["FetchCursor"]
 	return resp.(*proto.FetchCursorResponse), nil
 }

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -94,14 +94,14 @@ func (b *BrokerInfo) Addr() string {
 
 // PartitionMetadata ontains an immutable snapshot of information for a partition
 type PartitionMetadata struct {
-	id            int32
-	leader        string
-	replicas      []string
-	isr           []string
-	highWatermark int64
-	newestOffset  int64
-	paused        bool
-	lastUpdated   time.Time
+	ID            int32
+	Leader        string
+	Replicas      []string
+	Isr           []string
+	HighWatermark int64
+	NewestOffset  int64
+	Paused        bool
+	LastUpdated   time.Time
 }
 
 // Metadata contains an immutable snapshot of information for a cluster and

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -92,6 +92,18 @@ func (b *BrokerInfo) Addr() string {
 	return fmt.Sprintf("%s:%d", b.host, b.port)
 }
 
+// PartitionMetadata ontains an immutable snapshot of information for a partition
+type PartitionMetadata struct {
+	id            int32
+	leader        string
+	replicas      []string
+	isr           []string
+	highWatermark int64
+	newestOffset  int64
+	paused        bool
+	lastUpdated   time.Time
+}
+
 // Metadata contains an immutable snapshot of information for a cluster and
 // subset of streams.
 type Metadata struct {

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -32,11 +32,13 @@ func (s *StreamInfo) Partitions() map[int32]*PartitionInfo {
 
 // PartitionInfo contains information for a Liftbridge stream partition.
 type PartitionInfo struct {
-	id       int32
-	leader   *BrokerInfo
-	replicas []*BrokerInfo
-	isr      []*BrokerInfo
-	paused   bool
+	id            int32
+	leader        *BrokerInfo
+	replicas      []*BrokerInfo
+	isr           []*BrokerInfo
+	highWatermark int64
+	newestOffset  int64
+	paused        bool
 }
 
 // ID of the partition.
@@ -65,6 +67,16 @@ func (p *PartitionInfo) Paused() bool {
 	return p.paused
 }
 
+// HighWatermark returns highwatermark of the partition leader
+func (p *PartitionInfo) HighWatermark() int64 {
+	return p.highWatermark
+}
+
+// NewestOffset returns newestoffset of the partition leader
+func (p *PartitionInfo) NewestOffset() int64 {
+	return p.newestOffset
+}
+
 // BrokerInfo contains information for a Liftbridge cluster node.
 type BrokerInfo struct {
 	id   string
@@ -90,18 +102,6 @@ func (b *BrokerInfo) Port() int32 {
 // Addr returns <host>:<port> for the broker server.
 func (b *BrokerInfo) Addr() string {
 	return fmt.Sprintf("%s:%d", b.host, b.port)
-}
-
-// PartitionMetadata ontains an immutable snapshot of information for a partition
-type PartitionMetadata struct {
-	ID            int32
-	Leader        string
-	Replicas      []string
-	Isr           []string
-	HighWatermark int64
-	NewestOffset  int64
-	Paused        bool
-	LastUpdated   time.Time
 }
 
 // Metadata contains an immutable snapshot of information for a cluster and


### PR DESCRIPTION
Implement the rpc call for [`FetchPartitionMetadata`](https://github.com/liftbridge-io/liftbridge/blob/master/documentation/client_implementation.md#fetchpartitionmetadata)


Related [issues](https://github.com/liftbridge-io/go-liftbridge/issues/87)

