### PR TITLE
Metadata: add missing getters for the stream name and subject

### DIFF
--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1276,7 +1276,7 @@ func TestFetchMetadata(t *testing.T) {
 		}},
 		Metadata: []*proto.StreamMetadata{{
 			Name:    "foo",
-			Subject: "foo",
+			Subject: "foo-subject",
 			Partitions: map[int32]*proto.PartitionMetadata{
 				0: {
 					Id:       0,
@@ -1304,6 +1304,8 @@ func TestFetchMetadata(t *testing.T) {
 
 	stream := metadata.GetStream("foo")
 	require.NotNil(t, stream)
+	require.Equal(t, "foo-subject", stream.Subject())
+	require.Equal(t, "foo", stream.Name())
 	require.Len(t, stream.Partitions(), 1)
 	partition := stream.GetPartition(0)
 	require.NotNil(t, partition)

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -19,6 +19,16 @@ type StreamInfo struct {
 	creationTime time.Time
 }
 
+// Subject returns the stream's subject.
+func (s *StreamInfo) Subject() string {
+	return s.subject
+}
+
+// Name returns the stream's name.
+func (s *StreamInfo) Name() string {
+	return s.name
+}
+
 // GetPartition returns the partition info for the given partition id or nil if
 // no such partition exists.
 func (s *StreamInfo) GetPartition(id int32) *PartitionInfo {


### PR DESCRIPTION
This PR adds two missing getters for StreamInfo's name and subject.