### PR TITLE
Add support for Optimistic Concurrency Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ client.CreateStream(context.Background(), subject, name,
     lift.RetentionMaxBytes(134217728), lift.CompactEnabled(true))
 ```
 
-Also, the client has the possibilty to create a stream with enforced Optimistic Concurrency Control.
+Also, the client has the possibility to create a stream with enforced Optimistic Concurrency Control.
 This will create a stream and enable Optimistic Concurrency Control on that specific stream.
 
 
@@ -205,11 +205,15 @@ Also, on specific streams where Optimistic Concurrency Control is enabled,
 the client has to publish a message with `ExpectedOffset`. The `ExpectedOffset` is the
 offset that should be on the stream's partition if the message is published successfully.
 
-Note: as the error of concurrency is piggybacked via the `Ack`, so `AckPolicy` has to be set
+*Note*: as the error of concurrency is piggybacked via the `Ack`, so `AckPolicy` has to be set
 to use this feature.
 
+*Note*: by default, Liftbridge concurrency control considers the `ExpectedOffset` value -1 to be the signil
+to indicate default behavior: next offset, i.e: simply skip the concurrency control verification. By default,
+to provide compatibility, the client should make sure that this value is always set to -1 when concurrency control is not used.
+
 ```golang
-	// Publish Async with expected offfset
+	// Publish Async with expected offset
 	err = client.PublishAsync(context.Background(), "foo", []byte("hello"),
 		func(ack *lift.Ack, err error) {
 			errorC <- err

--- a/v2/client.go
+++ b/v2/client.go
@@ -1399,13 +1399,14 @@ func (c *client) newPublishRequest(ctx context.Context, stream string, value []b
 	}
 
 	return &proto.PublishRequest{
-		Stream:        stream,
-		Partition:     partition,
-		Key:           opts.Key,
-		Value:         value,
-		AckInbox:      opts.AckInbox,
-		CorrelationId: opts.CorrelationID,
-		AckPolicy:     opts.AckPolicy.toProto(),
+		Stream:         stream,
+		Partition:      partition,
+		Key:            opts.Key,
+		Value:          value,
+		AckInbox:       opts.AckInbox,
+		CorrelationId:  opts.CorrelationID,
+		AckPolicy:      opts.AckPolicy.toProto(),
+		ExpectedOffset: opts.ExpectedOffset,
 	}, nil
 }
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -1102,6 +1102,12 @@ func (c *client) Publish(ctx context.Context, stream string, value []byte,
 	options ...MessageOption) (*Ack, error) {
 
 	opts := &MessageOptions{Headers: make(map[string][]byte)}
+
+	// set expected offset to -1 to inicate next offset.
+	// this will keep clients that are not yet providing support for Optimistic Concurrency Control
+	// to operate normally.
+	opts.ExpectedOffset = -1
+
 	for _, opt := range options {
 		opt(opts)
 	}
@@ -1142,6 +1148,12 @@ func (c *client) PublishAsync(ctx context.Context, stream string, value []byte,
 	ackHandler AckHandler, options ...MessageOption) error {
 
 	opts := &MessageOptions{Headers: make(map[string][]byte)}
+
+	// set expected offset to -1 to inicate next offset.
+	// this will keep clients that are not yet providing support for Optimistic Concurrency Control
+	// to operate normally.
+	opts.ExpectedOffset = -1
+
 	for _, opt := range options {
 		opt(opts)
 	}

--- a/v2/client.go
+++ b/v2/client.go
@@ -180,9 +180,9 @@ type StreamOptions struct {
 	// default value.
 	MinISR *int
 
-	// OptimisticConcurrencyControlEna.bled controls the activation of optimistic concurrency control
+	// OptimisticConcurrencyControl controls the activation of optimistic concurrency control
 	// of the stream
-	OptimisticConcurrencyControlEnabled *bool
+	OptimisticConcurrencyControl *bool
 }
 
 func (s *StreamOptions) newRequest(subject, name string) *proto.CreateStreamRequest {
@@ -226,8 +226,8 @@ func (s *StreamOptions) newRequest(subject, name string) *proto.CreateStreamRequ
 	if s.MinISR != nil {
 		req.MinIsr = &proto.NullableInt32{Value: int32(*s.MinISR)}
 	}
-	if s.OptimisticConcurrencyControlEnabled != nil {
-		req.OptimisticConcurrencyControl = &proto.NullableBool{Value: *s.OptimisticConcurrencyControlEnabled}
+	if s.OptimisticConcurrencyControl != nil {
+		req.OptimisticConcurrencyControl = &proto.NullableBool{Value: *s.OptimisticConcurrencyControl}
 	}
 	return req
 }
@@ -416,7 +416,7 @@ func MinISR(minISR int) StreamOption {
 // effectively enables the behavior to control concurrency message publish
 func OptimisticConcurrencyControl(val bool) StreamOption {
 	return func(o *StreamOptions) error {
-		o.OptimisticConcurrencyControlEnabled = &val
+		o.OptimisticConcurrencyControl = &val
 		return nil
 	}
 }

--- a/v2/client.go
+++ b/v2/client.go
@@ -179,6 +179,10 @@ type StreamOptions struct {
 	// before it can be committed. If this is not set, it uses the server
 	// default value.
 	MinISR *int
+
+	// OptimisticConcurrencyControlEna.bled controls the activation of optimistic concurrency control
+	// of the stream
+	OptimisticConcurrencyControlEnabled *bool
 }
 
 func (s *StreamOptions) newRequest(subject, name string) *proto.CreateStreamRequest {
@@ -221,6 +225,9 @@ func (s *StreamOptions) newRequest(subject, name string) *proto.CreateStreamRequ
 	}
 	if s.MinISR != nil {
 		req.MinIsr = &proto.NullableInt32{Value: int32(*s.MinISR)}
+	}
+	if s.OptimisticConcurrencyControlEnabled != nil {
+		req.OptimisticConcurrencyControl = &proto.NullableBool{Value: *s.OptimisticConcurrencyControlEnabled}
 	}
 	return req
 }
@@ -401,6 +408,15 @@ func AutoPauseDisableIfSubscribers(val bool) StreamOption {
 func MinISR(minISR int) StreamOption {
 	return func(o *StreamOptions) error {
 		o.MinISR = &minISR
+		return nil
+	}
+}
+
+// OptimisticConcurrencyControl sets the value of OptimisticConcurrencyControl, which
+// effectively enables the behavior to control concurrency message publish
+func OptimisticConcurrencyControl(val bool) StreamOption {
+	return func(o *StreamOptions) error {
+		o.OptimisticConcurrencyControlEnabled = &val
 		return nil
 	}
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256
+	github.com/liftbridge-io/liftbridge-api v1.3.1-0.20201124191421-8ceb6d0858ac
 	github.com/nats-io/nats-server/v2 v2.1.4 // indirect
 	github.com/nats-io/nats.go v1.9.2
 	github.com/nats-io/nuid v1.0.1

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201003172511-d603f70cc6a1
+	github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256
 	github.com/nats-io/nats-server/v2 v2.1.4 // indirect
 	github.com/nats-io/nats.go v1.9.2
 	github.com/nats-io/nuid v1.0.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -38,6 +38,8 @@ github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201022201130-7ae2595b40b7 h1:
 github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201022201130-7ae2595b40b7/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256 h1:2pZtC3v6IBTwE70xfb/k0DPlOJ6BlXpthCUWrxCnhwo=
 github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
+github.com/liftbridge-io/liftbridge-api v1.3.1-0.20201124191421-8ceb6d0858ac h1:dK40hYiDOjtY/UagBmkrO50e2Rvm3Q5D1cmKODrT4TQ=
+github.com/liftbridge-io/liftbridge-api v1.3.1-0.20201124191421-8ceb6d0858ac/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -34,8 +34,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201003172511-d603f70cc6a1 h1:tHXrZCYAg5Yp6JdtaloZeY/rQqXExrv+jSW1dTbCHm8=
-github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201003172511-d603f70cc6a1/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
+github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201022201130-7ae2595b40b7 h1:xrF+cDIKVXEzs3dizCDU8SCgC9prT3X562D72iU4W/I=
+github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201022201130-7ae2595b40b7/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
+github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256 h1:2pZtC3v6IBTwE70xfb/k0DPlOJ6BlXpthCUWrxCnhwo=
+github.com/liftbridge-io/liftbridge-api v1.1.1-0.20201029165056-10f2aa65f256/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=

--- a/v2/message.go
+++ b/v2/message.go
@@ -442,7 +442,7 @@ func ExpectedOffset(expectedOffset int64) MessageOption {
 // NewMessage returns a serialized message for the given payload and options.
 func NewMessage(value []byte, options ...MessageOption) []byte {
 	opts := &MessageOptions{Headers: make(map[string][]byte)}
-	// set expected offset to -1 to inicate next offset.
+	// set expected offset to -1 to indicate next offset.
 	// this will keep clients that are not yet providing support for Optimistic Concurrency Control
 	// to operate normally.
 	opts.ExpectedOffset = -1

--- a/v2/message.go
+++ b/v2/message.go
@@ -313,6 +313,7 @@ type MessageOptions struct {
 
 	// ExpectedOffset set the value of the expected offset after publishing the message.
 	// This is required in case Optimistic Concurrency Control is activted
+	// by default, this value should be set to -1 to indicate next offset.
 	ExpectedOffset int64
 }
 
@@ -430,9 +431,9 @@ func PartitionByRoundRobin() MessageOption {
 	return PartitionBy(partitionByRoundRobin)
 }
 
-// SetExpectedOffset set the value of expected offset after publishing the message.
+// ExpectedOffset set the value of expected offset after publishing the message.
 // This is required for optimistic concurrency control
-func SetExpectedOffset(expectedOffset int64) MessageOption {
+func ExpectedOffset(expectedOffset int64) MessageOption {
 	return func(o *MessageOptions) {
 		o.ExpectedOffset = expectedOffset
 	}
@@ -441,6 +442,11 @@ func SetExpectedOffset(expectedOffset int64) MessageOption {
 // NewMessage returns a serialized message for the given payload and options.
 func NewMessage(value []byte, options ...MessageOption) []byte {
 	opts := &MessageOptions{Headers: make(map[string][]byte)}
+	// set expected offset to -1 to inicate next offset.
+	// this will keep clients that are not yet providing support for Optimistic Concurrency Control
+	// to operate normally.
+	opts.ExpectedOffset = -1
+
 	// TODO: Implement option for CRC32.
 	for _, opt := range options {
 		opt(opts)


### PR DESCRIPTION
To support [Optimistic Concurrency Control](https://github.com/liftbridge-io/liftbridge/issues/54), the following changes are needed in the client : 

-  Add function to enable `OptimisticConcurrencyControl` on `CreateStream`. 
-  Add function to take `ExpectedOffset` as params on `Publish`

This PR is the prerequisite for https://github.com/liftbridge-io/liftbridge/pull/296 