### PR TITLE
Add a ConnectCtx function to initiate a connection using a context

### DIFF
--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1408,6 +1408,19 @@ func TestResubscribeFail(t *testing.T) {
 	}
 }
 
+func TestConnectionContextDeadlineExceeded(t *testing.T) {
+	server := newMockServer()
+	defer server.Stop(t)
+	port := server.Start(t)
+
+	// Use a context with an already exceeded deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+
+	_, err := ConnectCtx(ctx, []string{fmt.Sprintf("localhost:%d", port)})
+	require.Equal(t, context.DeadlineExceeded, err)
+}
+
 func TestStreamOptionsNewRequest(t *testing.T) {
 	var (
 		retentionMaxBytes             = int64(1024)

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -243,10 +243,10 @@ type metadataCache struct {
 	mu             sync.RWMutex
 	metadata       *Metadata
 	bootstrapAddrs []string
-	doRPC          func(func(proto.APIClient) error) error
+	doRPC          func(context.Context, func(proto.APIClient) error) error
 }
 
-func newMetadataCache(addrs []string, doRPC func(func(proto.APIClient) error) error) *metadataCache {
+func newMetadataCache(addrs []string, doRPC func(context.Context, func(proto.APIClient) error) error) *metadataCache {
 	return &metadataCache{
 		metadata:       &Metadata{},
 		bootstrapAddrs: addrs,
@@ -258,7 +258,7 @@ func newMetadataCache(addrs []string, doRPC func(func(proto.APIClient) error) er
 // information.
 func (m *metadataCache) update(ctx context.Context) (*Metadata, error) {
 	var resp *proto.FetchMetadataResponse
-	if err := m.doRPC(func(client proto.APIClient) (err error) {
+	if err := m.doRPC(ctx, func(client proto.APIClient) (err error) {
 		resp, err = client.FetchMetadata(ctx, &proto.FetchMetadataRequest{})
 		return err
 	}); err != nil {


### PR DESCRIPTION
This adds a new `ConnectCtx` function that allows connecting using a context, so that the connection can be cancelled using a deadline other than the default gRPC one. The connection is only blocking if a context with a deadline has been provided.

This PR fixes https://github.com/liftbridge-io/go-liftbridge/issues/98.