### PR TITLE
Add headers to published messages

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -1484,6 +1484,7 @@ func (c *client) newPublishRequest(ctx context.Context, stream string, value []b
 		Partition:      partition,
 		Key:            opts.Key,
 		Value:          value,
+		Headers:        opts.Headers,
 		AckInbox:       opts.AckInbox,
 		CorrelationId:  opts.CorrelationID,
 		AckPolicy:      opts.AckPolicy.toProto(),

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1134,7 +1134,7 @@ func TestPublishToPartition(t *testing.T) {
 	require.Equal(t, []byte("hello"), req.Value)
 	require.Equal(t, "foo", req.Stream)
 	require.Equal(t, int32(1), req.Partition)
-	require.Equal(t, map[string][]byte(nil), req.Headers)
+	require.Equal(t, map[string][]byte{"foo": []byte("bar")}, req.Headers)
 	require.Equal(t, "", req.AckInbox)
 	require.NotEqual(t, "", req.CorrelationId)
 	require.Equal(t, proto.AckPolicy_ALL, req.AckPolicy)


### PR DESCRIPTION
Without this change, headers are omitted from messages published to the
Liftbridge API.