### PR TITLE
Make subscribe more resilient

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -1582,7 +1582,7 @@ func (c *client) subscribe(ctx context.Context, stream string,
 	for i := 0; i < 5; i++ {
 		client, err = c.getAPIClient(stream, opts.Partition, opts.ReadISRReplica)
 		if err != nil {
-			sleepContext(ctx, 50*time.Millisecond)
+			sleepContext(ctx, time.Duration(10+i*50)*time.Millisecond)
 			c.updateMetadata(ctx)
 			continue
 		}
@@ -1601,7 +1601,7 @@ func (c *client) subscribe(ctx context.Context, stream string,
 		st, err = client.Subscribe(ctx, req)
 		if err != nil {
 			if status.Code(err) == codes.Unavailable {
-				sleepContext(ctx, 50*time.Millisecond)
+				sleepContext(ctx, time.Duration(10+i*50)*time.Millisecond)
 				c.updateMetadata(ctx)
 				continue
 			}
@@ -1620,6 +1620,10 @@ func (c *client) subscribe(ctx context.Context, stream string,
 		}
 		if err != nil {
 			switch status.Code(err) {
+			case codes.Unavailable:
+				sleepContext(ctx, time.Duration(10+i*50)*time.Millisecond)
+				c.updateMetadata(ctx)
+				continue
 			case codes.NotFound:
 				err = ErrNoSuchPartition
 			case codes.ResourceExhausted:

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -743,12 +743,12 @@ func TestSubscribeServerUnavailableRetry(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
+	// Stop the server.
 	server.Stop(t)
 	server = newMockServer()
-
 	server.SetAutoClearError()
-
 	defer server.Stop(t)
+
 	server.SetupMockFetchMetadataResponse(metadataResp)
 	timestamp := time.Now().UnixNano()
 	messages := []*proto.Message{
@@ -770,6 +770,7 @@ func TestSubscribeServerUnavailableRetry(t *testing.T) {
 	server.SetupMockSubscribeAsyncError(status.Error(codes.Unavailable, "temporarily unavailable"))
 	server.SetupMockSubscribeMessages(messages)
 
+	// Delay the start until after the subscribe call to force a retry.
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		server.StartOnPort(t, port)

--- a/v2/common_test.go
+++ b/v2/common_test.go
@@ -56,6 +56,7 @@ func newMockServer() *mockServer {
 	return &mockServer{
 		Server:  server,
 		mockAPI: api,
+		stopped: make(chan struct{}),
 	}
 }
 
@@ -74,7 +75,6 @@ func (m *mockServer) startOnPort(t require.TestingT, port int) int {
 		require.NoError(t, m.Serve(l))
 	}()
 	m.listener = l
-	m.stopped = make(chan struct{})
 
 	var (
 		addr     = l.Addr()


### PR DESCRIPTION
If the subscribe streaming RPC recv fails due to a disconnect error even
after the initial subscribe RPC succeeds, retry the RPC sequence. This
makes subscribe more resilient to transient connection issues.